### PR TITLE
Update JDBC-Driver to 11.2.3.jre8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 6.0.1
+* Updated JDBC-Driver and [the one provided by Maven Central](https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc)
+
 ## 6.0.0
-* Inital open-source release
+* Initial open-source release

--- a/pom.xml
+++ b/pom.xml
@@ -60,14 +60,6 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <!-- Required for com.microsoft.sqlserver:sqljdbc4 -->
-            <id>clojars-JDBC</id>
-            <url>https://clojars.org/repo/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
     </repositories>
 
 
@@ -101,10 +93,11 @@
             <version>6.0.1</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc -->
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
-            <artifactId>sqljdbc4</artifactId>
-            <version>4.0</version>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>11.2.3.jre8</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
According to the support matrix, there are no conflicts with our code. However, the adapter will lose the compatibility with JRE 1.5 to 1.7.
For more details read through the comment in the following issue:  https://github.com/xdev-software/xapi-db-mssql-2012/issues/5